### PR TITLE
Add support for parsing defaultProps

### DIFF
--- a/src/fixtures/fixture008.js
+++ b/src/fixtures/fixture008.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function MyComponent({ className }) {
+	return <div className={className}></div>;
+}
+
+MyComponent.propTypes = {
+	className: PropTypes.string.isRequired,
+	optional: PropTypes.string,
+	optionalFlag: PropTypes.bool,
+};
+
+MyComponent.defaultProps = {
+	optional: 'default',
+	optionalFlag: true,
+};

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -136,3 +136,15 @@ test('fixture 007: jsdoc', async () => {
 	);
 	expect(text.startsWith('/**')).toBe(true);
 });
+
+test('fixture 008: defaultProps', async () => {
+	const result = await processFile(
+		path.resolve(__dirname, './fixtures/fixture008.js'),
+	);
+	expect(result).not.toBe(null);
+	expect(result!.has('MyComponent')).toBe(true);
+
+	const component = result!.get('MyComponent')!;
+	expect(component.defaultProps).not.toBe(null);
+	expect(component.defaultProps!.has('optional')).toBe(true);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
 		"skipLibCheck": true /* Skip type checking all .d.ts files. */,
 		"noUnusedLocals": true,
 		"outDir": "build",
-		"declaration": true
+		"declaration": true,
+		"resolveJsonModule": true
 	},
 	"include": ["src"],
 	"exclude": ["src/**/*.test.ts"]


### PR DESCRIPTION
- Adds support for parsing `defaultProps` and building a parameter suitable for functional components.
- The CLI now has a `--props` (`-p`) option for including this information when parsing
- Component information now has a `parameterRange` which is the position of the first argument for the component.